### PR TITLE
build: Fix warnings from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8...3.13)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
@@ -90,8 +90,8 @@ set(DEFAULT_MASTER_HOSTNAME      "mfsmaster"                CACHE STRING "Defaul
 set(DEFAULT_MASTER_PORT          "9421"                     CACHE STRING "Default master server port number")
 set(DEFAULT_MOUNTED_SUBFOLDER    "/"                        CACHE STRING "Default subfolder to be mounted")
 set(DEFAULT_MFSMOUNT_CONFIG_PATH "${ETC_PATH}/mfsmount.cfg" CACHE STRING "Default full path to mfsmount configuration file")
-set(LIZARDFS_BLOCKS_IN_CHUNK     1024                       CACHE INT "Number of blocks in one chunk")
-set(LIZARDFS_BLOCK_SIZE          65536                      CACHE INT "Number of bytes in one block")
+set(LIZARDFS_BLOCKS_IN_CHUNK     "1024"                     CACHE STRING "Number of blocks in one chunk")
+set(LIZARDFS_BLOCK_SIZE          "65536"                    CACHE STRING "Number of bytes in one block")
 
 message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 message(STATUS "CMAKE_INSTALL_PREFIX: ${CMAKE_INSTALL_PREFIX}")

--- a/cmake/FindJudy.cmake
+++ b/cmake/FindJudy.cmake
@@ -43,5 +43,5 @@ check_c_source_runs("${_CHECK_FOR_JUDY1_BUG}" JUDY_HAVE_WORKING_JUDY1)
 unset(CMAKE_REQUIRED_INCLUDES)
 unset(CMAKE_REQUIRED_LIBRARIES)
 
-find_package_handle_standard_args(JUDY
+find_package_handle_standard_args(Judy
                                   REQUIRED_VARS JUDY_LIBRARY JUDY_INCLUDE_DIR)


### PR DESCRIPTION
This commit fixes some warnings on CMake configuration stage:
- CMake minimal version deprecation
- Mismatch between JUDY and Judy
- Implicit conversion from INT to STRING

Change-Id: Ic3a21bf5ee61565502f16915a9891f3575d971a9